### PR TITLE
AccessPointConfiguration: fix max_connections default value

### DIFF
--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -157,7 +157,7 @@ impl Default for AccessPointConfiguration {
             protocols: Protocol::P802D11B | Protocol::P802D11BG | Protocol::P802D11BGN,
             auth_method: AuthMethod::None,
             password: "".into(),
-            max_connections: 256,
+            max_connections: 255,
             ip_conf: Some(Default::default()),
         }
     }


### PR DESCRIPTION
Using the following code:
```rs
pub fn access_point() -> Result<Box<impl Wifi>> {
    let mut wifi = Box::new(EspWifi::new(
        Arc::new(EspNetif::new()?),
        Arc::new(EspSysLoop::new()?),
        Arc::new(EspDefaultNvs::new()?),
    )?);

    wifi.set_configuration(&Configuration::AccessPoint(Default::default()))?;
    Ok(wifi)
}
```

I'm unable to connect to the AP of my device. The issue seems to stem from the fact that the default value for `AccessPointConfiguration::max_connections` is 256, which is out of `u8` range. 

https://github.com/esp-rs/esp-idf-svc/blob/7194cd16fef0d1adf5aa2e123a9e7ae930d18fb3/src/wifi.rs#L117

There we see this value gets cast to an `u8`. This means the default `256_u16` becomes `0_u8`, causing a max connections failure whenever a client tries to connect to the AP:
```
I (586) esp_idf_svc::wifi: Driver initialized
I (586) esp_idf_svc::wifi: Event handlers registered
I (596) esp_idf_svc::wifi: Initialization complete
I (606) esp_idf_svc::wifi: Setting configuration: AccessPoint(AccessPointConfiguration { ssid: "iot-device", ssid_hidden: false, channel: 1, secondary_channel: None, protocols: EnumSet(P802D11B | P802D11BG | P802D11BGN), auth_method: None, password: "", max_connections: 256, ip_conf: Some(RouterConfiguration { subnet: Subnet { gateway: 192.168.71.1, mask: Mask(24) }, dhcp_enabled: true, dns: Some(8.8.8.8), secondary_dns: Some(8.8.4.4) }) })
I (636) esp_idf_svc::wifi: Stopping
I (646) esp_idf_svc::wifi: Disconnect requested
I (646) esp_idf_svc::wifi: Stop requested
I (656) esp_idf_svc::wifi: About to wait for status
I (656) esp_idf_svc::wifi: Providing status: Status(Stopped, Stopped)
I (666) esp_idf_svc::wifi: Waiting for status done - success
I (676) esp_idf_svc::wifi: Stopped
I (676) esp_idf_svc::wifi: Wifi mode AP set
I (686) esp_idf_svc::wifi: Setting AP configuration: AccessPointConfiguration { ssid: "iot-device", ssid_hidden: false, channel: 1, secondary_channel: None, protocols: EnumSet(P802D11B | P802D11BG | P802D11BGN), auth_method: None, password: "", max_connections: 256, ip_conf: Some(RouterConfiguration { subnet: Subnet { gateway: 192.168.71.1, mask: Mask(24) }, dhcp_enabled: true, dns: Some(8.8.8.8), secondary_dns: Some(8.8.4.4) }) }
I (726) esp_idf_svc::wifi: Setting AP IP configuration: RouterConfiguration { subnet: Subnet { gateway: 192.168.71.1, mask: Mask(24) }, dhcp_enabled: true, dns: Some(8.8.8.8), secondary_dns: Some(8.8.4.4) }
I (736) esp_idf_svc::wifi: AP netif allocated: 0x3fca4e88
I (746) esp_idf_svc::wifi: AP IP configuration done
I (756) esp_idf_svc::wifi: AP configuration done
I (756) esp_idf_svc::wifi: Starting with status: Status(Stopped, Starting)
I (766) esp_idf_svc::wifi: Status is of operating type, starting
I (776) phy_init: phy_version 500,985899c,Apr 19 2021,16:05:08
I (886) wifi:set rx active PTI: 0, rx ack PTI: 0, and default PTI: 0
I (886) wifi:mode : softAP (7c:df:a1:a4:44:c1)
I (886) wifi:Total power save buffer number: 16
I (896) wifi:Init max length of beacon: 752/752
I (896) wifi:Init max length of beacon: 752/752
I (896) esp_idf_svc::wifi: Got wifi event: 12 
I (906) esp_idf_svc::wifi: Set status: Status(Stopped, Started(Waiting))
I (916) esp_idf_svc::wifi: Wifi event 12 handled
I (916) esp_idf_svc::wifi: Start requested
I (926) esp_idf_svc::wifi: About to wait for status with timeout 10s
I (926) esp_idf_svc::wifi: Providing status: Status(Stopped, Started(Waiting))
I (5936) esp_idf_svc::wifi: Providing status: Status(Stopped, Started(Waiting))
I (7966) wifi:max connection, deauth!
I (8286) wifi:max connection, deauth!
I (8596) wifi:max connection, deauth!
I (8916) wifi:max connection, deauth!
I (9226) wifi:max connection, deauth!
I (9786) wifi:max connection, deauth!
I (10096) wifi:max connection, deauth!
I (10406) wifi:max connection, deauth!
I (10716) wifi:max connection, deauth!
I (11026) wifi:max connection, deauth!
```

This PR sets the max_connections default value to 255, which fixes the above issue.

The more appropriate solution would be to change the type of `max_connections` from `u16` to `u8`.
However, I'm not sure if this would impact other code?