### PR TITLE
Use `MacAddr6` type for BSSID.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ default = ["std", "use_serde", "use_strum", "use_numenum"]
 #experimental = ["futures", "domain"]
 experimental = ["futures"]
 
-std = ["alloc", "anyhow/std", "serde/std", "serde_json/std", "strum/std", "num_enum/std", "http-auth-basic"]
+std = ["alloc", "anyhow/std", "serde/std", "serde_json/std", "strum/std", "num_enum/std", "http-auth-basic", "macaddr/std"]
 alloc = ["anyhow", "serde/alloc", "serde_json/alloc"]
-use_serde = ["enumset/serde", "no-std-net/serde"]
+use_serde = ["enumset/serde", "no-std-net/serde", "macaddr/serde"]
 use_strum = ["strum", "strum_macros"]
 use_numenum = ["num_enum"]
 
@@ -31,6 +31,7 @@ enumset = { version = "1", default-features = false }
 anyhow = { version = "1", default-features = false, optional = true }
 strum = { version = "0.23", default-features = false, optional = true, features = ["derive"] }
 strum_macros = { version = "0.23", optional = true }
+macaddr = { version = "1", default-features = false }
 num_enum = { version = "0.5", default-features = false, optional = true }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, optional = true }

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -5,6 +5,7 @@ use core::mem;
 extern crate alloc;
 
 use enumset::*;
+use macaddr::MacAddr6;
 
 #[cfg(feature = "use_serde")]
 use serde::{Deserialize, Serialize};
@@ -141,7 +142,7 @@ impl Default for SecondaryChannel {
 #[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
 pub struct AccessPointInfo {
     pub ssid: alloc::string::String,
-    pub bssid: [u8; 6],
+    pub bssid: MacAddr6,
     pub channel: u8,
     pub secondary_channel: SecondaryChannel,
     pub signal_strength: u8,
@@ -204,7 +205,7 @@ impl Default for AccessPointConfiguration {
 #[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
 pub struct ClientConfiguration {
     pub ssid: alloc::string::String,
-    pub bssid: Option<[u8; 6]>,
+    pub bssid: Option<MacAddr6>,
     //pub protocol: Protocol,
     pub auth_method: AuthMethod,
     pub password: alloc::string::String,


### PR DESCRIPTION
This is a bit more expressive than `[u8; 6]` and provides a nice `Display` and `Debug` implementation.