### PR TITLE
fix: update signal strength as signed integer

### DIFF
--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -143,7 +143,7 @@ pub struct AccessPointInfo {
     pub bssid: [u8; 6],
     pub channel: u8,
     pub secondary_channel: SecondaryChannel,
-    pub signal_strength: u8,
+    pub signal_strength: i8,
     pub protocols: EnumSet<Protocol>,
     pub auth_method: AuthMethod,
 }


### PR DESCRIPTION
This commit fixes the unit of the received signal strength, as these are signed values (dBs).