### PR TITLE
align FirmwareInfo with esp_app_desc_t field size.

### DIFF
--- a/src/ota.rs
+++ b/src/ota.rs
@@ -17,9 +17,9 @@ pub struct Slot {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
 pub struct FirmwareInfo {
-    pub version: heapless::String<24>,
-    pub released: heapless::String<24>,
-    pub description: Option<heapless::String<128>>,
+    pub version: heapless::String<32>,
+    pub released: heapless::String<32>,
+    pub description: Option<heapless::String<32>>,
     pub signature: Option<heapless::Vec<u8, 32>>,
     pub download_id: Option<heapless::String<128>>,
 }


### PR DESCRIPTION
This PR addresses the differences (some fields are too small, one field is too large) in field sizes described in issue https://github.com/esp-rs/esp-idf-svc/issues/204. It ensures, that the fields in ```FirmwareInfo``` are large enough to hold the fields defined in ```esp_app_desc_t```. For details see the issue above.