### PR TITLE
Expose the 'asynch' Wifi module as public…

### DIFF
--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -425,7 +425,7 @@ where
 }
 
 #[cfg(all(feature = "nightly", feature = "experimental"))]
-mod asynch {
+pub mod asynch {
     use futures::Future;
 
     use super::*;


### PR DESCRIPTION
… so that it is possible to experiment with async Wifi implementations
