### PR TITLE
storage: add StorageIterate

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,4 +1,5 @@
 use core::any::Any;
+use core::ffi::CStr;
 use core::fmt::{self, Debug};
 
 use serde::de::DeserializeOwned;
@@ -132,6 +133,23 @@ where
     }
 }
 
+pub trait StorageIterate {
+    type Error: Debug;
+    type Entry: StorageEntry;
+    type Entries<'a>: Iterator<Item = Result<Self::Entry, Self::Error>>
+    where
+        Self: 'a;
+
+    fn entries<'a>(&'a self) -> Result<Self::Entries<'a>, Self::Error>;
+}
+
+pub trait StorageEntry {
+    fn name_cstr(&self) -> &CStr;
+    fn name(&self) -> Option<&str> {
+        self.name_cstr().to_str().ok()
+    }
+}
+
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum StorageError<R, S> {
@@ -261,6 +279,21 @@ where
         T: Serialize,
     {
         StorageImpl::set(self, name, value)
+    }
+}
+
+impl<const N: usize, R, S> StorageIterate for StorageImpl<N, R, S>
+where
+    S: SerDe,
+    R: StorageIterate,
+{
+    type Error = R::Error;
+    type Entry = R::Entry;
+    type Entries<'a> = R::Entries<'a>
+        where Self: 'a;
+
+    fn entries<'a>(&'a self) -> Result<Self::Entries<'a>, Self::Error> {
+        self.raw_storage.entries()
     }
 }
 


### PR DESCRIPTION
`StorageIterate` provides a way to iterate over all the keys within a `Storage` instance.

Some notes:

 - This borrows the `storage` instance while the iterator exists, even though this might not be needed by all implementations
 - This returns `Result<>` both on the initial `entries()` call and on each step. This mirrors https://doc.rust-lang.org/std/fs/fn.read_dir.html
 - I have no particular attachment to the name used.
 - Having the `StorageIterate::Error` type parameter makes things more flexible when layering over a `StorageImpl` compared to inheriting from `StorageBase`.
 - I'm not entirely happy with the `name()` and `name_cstr()` functions on each entry. They mainly exist because on esp-idf's nvs we have cstrings as the underlying data, and I did not want to prevent obtaining entries with non-utf-8 names. In practice, it might be ok to skip non-utf-8 entries instead of allowing access to the `CStr`.

---
I'll edit this to add a link to the esp-idf-svc PR implementing it