### PR TITLE
Make atomic-waker and serde optional, update heapless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.??.?] - ?
 * Added the opt-out `asyncify` feature. Disabling this feature removes the `atomic-waker` dependencies and removes the `utils::asyncify` module.
 * The `serde` dependency is now optional.
+* Update to `heapless` 0.8
 
 ## [0.26.4] - 2023-11-12
 * Updated changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.??.?] - ?
+* Added the opt-out `asyncify` feature. Disabling this feature removes the `atomic-waker` dependencies and removes the `utils::asyncify` module.
+* The `serde` dependency is now optional.
+
 ## [0.26.4] - 2023-11-12
 * Updated changelog
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,16 +13,17 @@ readme = "README.md"
 rust-version = "1.71"
 
 [features]
-default = ["std", "use_serde", "use_strum", "use_numenum", "log"]
+default = ["std", "use_serde", "use_strum", "use_numenum", "log", "asyncify"]
 
 std = ["alloc", "embedded-io/std", "embedded-io-async?/std", "serde/std", "strum?/std", "num_enum?/std"]
 alloc = ["embedded-io/alloc", "embedded-io-async?/alloc", "serde/alloc", "defmt?/alloc"]
 nightly = ["embedded-io-async", "embedded-hal-async"]
 experimental = []
-use_serde = ["enumset/serde", "no-std-net/serde", "heapless/serde"]
+use_serde = ["dep:serde", "enumset/serde", "no-std-net/serde", "heapless/serde"]
 use_strum = ["strum", "strum_macros"]
 use_numenum = ["num_enum"]
 defmt = ["dep:defmt", "heapless/defmt", "heapless/defmt-impl", "embedded-io/defmt-03", "embedded-io-async?/defmt-03", "embedded-hal-async?/defmt-03"]
+asyncify = ["dep:atomic-waker"]
 
 [dependencies]
 heapless = { version = "0.7" }
@@ -31,8 +32,8 @@ embedded-io-async = { version = "0.6", default-features = false, optional = true
 embedded-hal-async = { version = "=1.0.0-rc.1", default-features = false, optional = true }
 log = { version = "0.4", default-features = false, optional = true }
 no-std-net = { version = "0.5", default-features = false }
-serde = { version = "1", default-features = false, features = ["derive"] }
-atomic-waker = { version = "1.1.1", default-features = false }
+serde = { version = "1", default-features = false, features = ["derive"], optional = true }
+atomic-waker = { version = "1.1.1", default-features = false, optional = true }
 enumset = { version = "1", default-features = false }
 strum = { version = "0.25", default-features = false, optional = true, features = ["derive"] }
 strum_macros = { version = "0.25", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ experimental = []
 use_serde = ["dep:serde", "enumset/serde", "no-std-net/serde", "heapless/serde"]
 use_strum = ["strum", "strum_macros"]
 use_numenum = ["num_enum"]
-defmt = ["dep:defmt", "heapless/defmt", "heapless/defmt-impl", "embedded-io/defmt-03", "embedded-io-async?/defmt-03", "embedded-hal-async?/defmt-03"]
+defmt = ["dep:defmt", "heapless/defmt-03", "embedded-io/defmt-03", "embedded-io-async?/defmt-03", "embedded-hal-async?/defmt-03"]
 asyncify = ["dep:atomic-waker"]
 
 [dependencies]
-heapless = { version = "0.7" }
+heapless = { version = "0.8" }
 embedded-io = { version = "0.6", default-features = false }
 embedded-io-async = { version = "0.6", default-features = false, optional = true }
 embedded-hal-async = { version = "=1.0.0-rc.1", default-features = false, optional = true }

--- a/src/http.rs
+++ b/src/http.rs
@@ -170,6 +170,8 @@ where
 }
 
 pub mod headers {
+    use core::convert::TryFrom;
+
     pub type ContentLenParseBuf = heapless::String<20>;
 
     pub fn content_type(ctype: &str) -> (&str, &str) {
@@ -177,7 +179,7 @@ pub mod headers {
     }
 
     pub fn content_len(len: u64, buf: &mut ContentLenParseBuf) -> (&str, &str) {
-        *buf = ContentLenParseBuf::from(len);
+        *buf = ContentLenParseBuf::try_from(len).unwrap();
 
         ("Content-Length", buf.as_str())
     }

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -1,4 +1,7 @@
-use core::fmt::{self, Debug, Display, Write as _};
+use core::{
+    convert::TryInto,
+    fmt::{self, Debug, Display, Write as _},
+};
 
 use crate::io::{Error, Read, Write};
 
@@ -222,7 +225,7 @@ pub struct HandlerError(heapless::String<64>);
 
 impl HandlerError {
     pub fn new(message: &str) -> Self {
-        Self(message.into())
+        Self(message.try_into().unwrap())
     }
 
     pub fn message(&self) -> &str {
@@ -239,10 +242,10 @@ where
     E: Debug,
 {
     fn from(e: E) -> Self {
-        let mut string: heapless::String<64> = "".into();
+        let mut string = heapless::String::<64>::new();
 
         if write!(&mut string, "{e:?}").is_err() {
-            string = "(Error string too big)".into();
+            string = "(Error string too big)".try_into().unwrap();
         }
 
         Self(string)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "asyncify")]
 pub mod asyncify;
 pub mod http;
 pub mod io;

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1,3 +1,4 @@
+use core::convert::TryInto;
 use core::fmt::Debug;
 use core::mem;
 
@@ -157,13 +158,13 @@ pub struct AccessPointConfiguration {
 impl Default for AccessPointConfiguration {
     fn default() -> Self {
         Self {
-            ssid: "iot-device".into(),
+            ssid: "iot-device".try_into().unwrap(),
             ssid_hidden: false,
             channel: 1,
             secondary_channel: None,
             protocols: Protocol::P802D11B | Protocol::P802D11BG | Protocol::P802D11BGN,
             auth_method: AuthMethod::None,
-            password: "".into(),
+            password: heapless::String::new(),
             max_connections: 255,
         }
     }
@@ -195,10 +196,10 @@ impl Debug for ClientConfiguration {
 impl Default for ClientConfiguration {
     fn default() -> Self {
         ClientConfiguration {
-            ssid: "".into(),
+            ssid: heapless::String::new(),
             bssid: None,
             auth_method: Default::default(),
-            password: "".into(),
+            password: heapless::String::new(),
             channel: None,
         }
     }


### PR DESCRIPTION
I'm also updating heapless as 0.8 now uses portable-atomic (yaay). I guess it could have gone into a different PR, but I'm going ahead and avoiding a changelog conflict :)