### PR TITLE
Fix conditional `serde` usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
         run: cargo build --no-default-features --features experimental,nightly,alloc,use_serde,use_strum,use_numenum,log --target riscv32imc-esp-espidf -Zbuild-std=core,alloc,panic_abort -Zbuild-std-features=panic_immediate_abort
       - name: Build | Compile / no_std
         run: cargo build --no-default-features --features experimental,nightly,use_serde,use_strum,use_numenum,log --target riscv32imc-esp-espidf -Zbuild-std=core,alloc,panic_abort -Zbuild-std-features=panic_immediate_abort
+      - name: Build | Compile / no_std, no serde
+        run: cargo build --no-default-features --features experimental,nightly,use_strum,use_numenum,log --target riscv32imc-esp-espidf -Zbuild-std=core,alloc,panic_abort -Zbuild-std-features=panic_immediate_abort
       - name: Build | Compile / defmt
         run: cargo build --no-default-features --features std,experimental,nightly,use_serde,use_strum,use_numenum,defmt --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
       - name: Build | Compile / defmt, no_std

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod log;
 pub mod mqtt;
 pub mod ota;
 pub mod ping;
+#[cfg(feature = "storage")]
 pub mod storage;
 pub mod sys_time;
 pub mod timer;

--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -3,6 +3,7 @@ use core::fmt::{self, Debug, Display, Formatter};
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+#[cfg(feature = "use_serde")]
 use serde::{Deserialize, Serialize};
 
 pub trait ErrorType {
@@ -25,8 +26,9 @@ where
 
 /// Quality of service
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
 pub enum QoS {
     AtMostOnce = 0,
     AtLeastOnce = 1,
@@ -35,8 +37,9 @@ pub enum QoS {
 
 pub type MessageId = u32;
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
 pub enum Event<M> {
     BeforeConnect,
     Connected(bool),
@@ -159,22 +162,25 @@ impl Message for MessageImpl {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
 pub enum Details {
     Complete,
     InitialChunk(InitialChunkData),
     SubsequentChunk(SubsequentChunkData),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
 pub struct InitialChunkData {
     pub total_data_size: usize,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
 pub struct SubsequentChunkData {
     pub current_data_offset: usize,
     pub total_data_size: usize,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,8 +1,8 @@
 use core::any::Any;
 use core::fmt::{self, Debug};
 
-use serde::de::DeserializeOwned;
-use serde::Serialize;
+#[cfg(feature = "use_serde")]
+use serde::{de::DeserializeOwned, Serialize};
 
 pub trait StorageBase {
     type Error: Debug;
@@ -26,6 +26,7 @@ where
     }
 }
 
+#[cfg(feature = "use_serde")]
 pub trait Storage: StorageBase {
     fn get<T>(&self, name: &str) -> Result<Option<T>, Self::Error>
     where
@@ -36,6 +37,7 @@ pub trait Storage: StorageBase {
         T: serde::Serialize;
 }
 
+#[cfg(feature = "use_serde")]
 impl<S> Storage for &mut S
 where
     S: Storage,
@@ -99,6 +101,7 @@ where
     }
 }
 
+#[cfg(feature = "use_serde")]
 pub trait SerDe {
     type Error: Debug;
 
@@ -111,6 +114,7 @@ pub trait SerDe {
         T: DeserializeOwned;
 }
 
+#[cfg(feature = "use_serde")]
 impl<S> SerDe for &S
 where
     S: SerDe,
@@ -160,11 +164,13 @@ where
 {
 }
 
+#[cfg(feature = "use_serde")]
 pub struct StorageImpl<const N: usize, R, S> {
     raw_storage: R,
     serde: S,
 }
 
+#[cfg(feature = "use_serde")]
 impl<const N: usize, R, S> StorageImpl<N, R, S>
 where
     R: RawStorage,
@@ -236,6 +242,7 @@ where
     }
 }
 
+#[cfg(feature = "use_serde")]
 impl<const N: usize, R, S> StorageBase for StorageImpl<N, R, S>
 where
     R: RawStorage,
@@ -252,6 +259,7 @@ where
     }
 }
 
+#[cfg(feature = "use_serde")]
 impl<const N: usize, R, S> Storage for StorageImpl<N, R, S>
 where
     R: RawStorage,


### PR DESCRIPTION
This PR removes a bunch of code from `storage` when `use_serde` is not enabled. I've also changed a few unconditional derives in `mqtt::client`