### PR TITLE
Issue 333 in esp-idf-svc, panic during scan when wifi with authmethod unknown

### DIFF
--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -137,7 +137,7 @@ pub struct AccessPointInfo {
     pub signal_strength: i8,
     #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
     pub protocols: EnumSet<Protocol>,
-    pub auth_method: AuthMethod,
+    pub auth_method: Option<AuthMethod>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
Allow the representation of not understood/mapped authentication method
Related to https://github.com/esp-rs/esp-idf-svc/pull/335, please do not merge alone