### PR TITLE
update embedded-hal-async to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-svc"
-version = "0.26.4"
+version = "0.26.5"
 authors = ["Ivan Markov <ivan.markov@gmail.com>"]
 edition = "2018"
 resolver = "2"
@@ -29,7 +29,7 @@ asyncify = ["dep:atomic-waker"]
 heapless = { version = "0.8" }
 embedded-io = { version = "0.6", default-features = false }
 embedded-io-async = { version = "0.6", default-features = false, optional = true }
-embedded-hal-async = { version = "=1.0.0-rc.1", default-features = false, optional = true }
+embedded-hal-async = { version = "=1.0.0-rc.2", default-features = false, optional = true }
 log = { version = "0.4", default-features = false, optional = true }
 no-std-net = { version = "0.5", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"], optional = true }


### PR DESCRIPTION
A new release would also drop heapless 0.7 which means I can update some lagging versions in esp-wifi (and drop all my local patches :) )

https://github.com/esp-rs/esp-wifi/pull/408

I didn't update to rc 3 since there are some breaking changes that still need to propagate through the ecosystem (in my case, esp32-hal and friends)

See here https://github.com/rust-embedded/embedded-hal/blob/master/embedded-hal/CHANGELOG.md#v100-rc3---2023-12-14