### PR TITLE
Add more configuration options to wifi::ClientConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [?.??.?] - ????-??-??
+* Breaking change: Add configuration for Protected Management Frames and scan methods to `wifi::ClientConfiguration`
+
 ## [0.27.1] - 2024-02-21
 * Fix clippy duplicate imports warnings with latest 1.78 nightly
 

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -242,16 +242,20 @@ impl PmfConfiguration {
 }
 
 /// The scan method to use when connecting to an AP
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
 #[non_exhaustive]
 pub enum ScanMethod {
-    /// Scan every channel and connect according to [ScanSortMethod]
+    /// Scan every channel and connect according to [ScanSortMethod] (default)
     FullScan(ScanSortMethod),
-    /// Connect to the first found AP and stop scanning (default)
-    #[default]
+    /// Connect to the first found AP and stop scanning
     FastScan,
+}
+impl Default for ScanMethod {
+    fn default() -> Self {
+        Self::FullScan(ScanSortMethod::default())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -259,10 +263,10 @@ pub enum ScanMethod {
 #[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
 #[non_exhaustive]
 pub enum ScanSortMethod {
-    /// Sort by signal strength
-    Signal,
-    /// Sort by Security (default)
+    /// Sort by signal strength (default)
     #[default]
+    Signal,
+    /// Sort by Security
     Security,
 }
 

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -223,11 +223,32 @@ impl Default for ClientConfiguration {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "use_strum",
+    derive(EnumString, Display, EnumMessage, EnumIter, EnumVariantNames)
+)]
 pub enum PmfConfiguration {
     /// No support for PMF will be advertized (default)
     #[default]
+    #[cfg_attr(
+        feature = "use_strum",
+        strum(
+            serialize = "not_capable",
+            serialize = "pmf_disabled",
+            to_string = "PMF Disabled",
+            message = "Don't advertise PMF capabilities",
+        )
+    )]
     NotCapable,
     /// Advertize PMF support and wether PMF is required or not
+    #[cfg_attr(
+        feature = "use_strum",
+        strum(
+            serialize = "capable",
+            to_string = "PMF enabled",
+            message = "Advertise PMF capabilities",
+        )
+    )]
     Capable { required: bool },
 }
 impl PmfConfiguration {
@@ -245,28 +266,71 @@ impl PmfConfiguration {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "use_strum",
+    derive(EnumString, Display, EnumMessage, EnumIter, EnumVariantNames)
+)]
 #[non_exhaustive]
 pub enum ScanMethod {
     /// Scan every channel and connect according to [ScanSortMethod] (default)
-    FullScan(ScanSortMethod),
+    #[cfg_attr(
+        feature = "use_strum",
+        strum(
+            serialize = "complete_scan",
+            to_string = "Complete Scan",
+            message = "Do a complete scan",
+            detailed_message = "Scan all APs and sort by a criteria"
+        )
+    )]
+    CompleteScan(ScanSortMethod),
     /// Connect to the first found AP and stop scanning
+    #[cfg_attr(
+        feature = "use_strum",
+        strum(
+            serialize = "fast_scan",
+            to_string = "Fast Scan",
+            message = "Do a fast scan",
+            detailed_message = "Connect to the first matching AP"
+        )
+    )]
     FastScan,
 }
 impl Default for ScanMethod {
     fn default() -> Self {
-        Self::FullScan(ScanSortMethod::default())
+        Self::CompleteScan(ScanSortMethod::default())
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "use_strum",
+    derive(EnumString, Display, EnumMessage, EnumIter, EnumVariantNames)
+)]
 #[non_exhaustive]
 pub enum ScanSortMethod {
     /// Sort by signal strength (default)
     #[default]
+    #[cfg_attr(
+        feature = "use_strum",
+        strum(
+            serialize = "signal_strength",
+            serialize = "signal",
+            to_string = "Signal Strength",
+            message = "Sort by signal strength"
+        )
+    )]
     Signal,
     /// Sort by Security
+    #[cfg_attr(
+        feature = "use_strum",
+        strum(
+            serialize = "security",
+            to_string = "Security",
+            message = "Sort by security"
+        )
+    )]
     Security,
 }
 

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -245,6 +245,7 @@ impl PmfConfiguration {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub enum ScanMethod {
     /// Scan every channel and connect according to [ScanSortMethod]
     FullScan(ScanSortMethod),
@@ -256,6 +257,7 @@ pub enum ScanMethod {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub enum ScanSortMethod {
     /// Sort by signal strength
     Signal,


### PR DESCRIPTION
Adds fields to configure Protected Management Frames (PMF) and scan method to `wifi::ClientConfiguration`.

PMF can be configured as
```rust
pub enum PmfConfiguration {
    /// No support for PMF will be advertized (default)
    #[default]
    NotCapable,
    /// Advertize PMF support and wether PMF is required or not
    Capable { required: bool },
}
```

and scan methods are also available the way esp-idf exposes them:
```rust
pub enum ScanMethod {
    /// Scan every channel and connect according to [ScanSortMethod]
    FullScan(ScanSortMethod),
    /// Connect to the first found AP and stop scanning (default)
    #[default]
    FastScan,
}

pub enum ScanSortMethod {
    /// Sort by signal strength
    Signal,
    /// Sort by Security (default)
    #[default]
    Security,
}
```
they are also marked `non_exhaustive` since other scan methods may be possible.