### PR TITLE
mqtt connected event -> session_present

### DIFF
--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -85,7 +85,7 @@ where
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::BeforeConnect => write!(f, "BeforeConnect"),
-            Self::Connected(connected) => write!(f, "Connected(session: {connected})"),
+            Self::Connected(session_present) => write!(f, "Connected(session: {session_present})"),
             Self::Disconnected => write!(f, "Disconnected"),
             Self::Subscribed(message_id) => write!(f, "Subscribed({message_id})"),
             Self::Unsubscribed(message_id) => write!(f, "Unsubscribed({message_id})"),


### PR DESCRIPTION
rename connected to naming used in idf core and reduce misunderstandings about meaning.
https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/protocols/mqtt.html#_CPPv4N19esp_mqtt_event_id_t20MQTT_EVENT_CONNECTEDE