### PR TITLE
Add serde defaults to the client configuration struct

### DIFF
--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -187,8 +187,10 @@ pub struct ClientConfiguration {
     /// at the channel the target AP is on.
     pub channel: Option<u8>,
     /// The scan method to use when searching for the target AP
+    #[cfg_attr(feature = "use_serde", serde(default))]
     pub scan_method: ScanMethod,
     /// Protected Management Frame configuration
+    #[cfg_attr(feature = "use_serde", serde(default))]
     pub pmf_cfg: PmfConfiguration,
 }
 


### PR DESCRIPTION
When deserializing this before the addition of PMF and scan method, one could pass a json struct containing just  `r#"{"ssid":"abc", "auth_method":"WPA2Personal", "password":"123"}"#`

And this would automatically deserialize despite omitting the `bssid` and `channel`, neither of which are usually known when connecting to WiFi.

The new code uses the defaults for scan method and PMF config, which are more of an advanced use-case concern.