### PR TITLE
Add missing default serde flags for ClientConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking
 
 ### Added
+- Add serde defaults for authentication method and password fields of ClientConfiguration struct (#82)
 
 ### Fixed
 - Remove `DynStorageImpl` as nobody used it BECAUSE it did not have a public constructor ANYWAY

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -179,7 +179,9 @@ pub struct ClientConfiguration {
     /// BSSID of the target AP
     pub bssid: Option<[u8; 6]>,
     //pub protocol: Protocol,
+    #[cfg_attr(feature = "use_serde", serde(default))]
     pub auth_method: AuthMethod,
+    #[cfg_attr(feature = "use_serde", serde(default))]
     pub password: heapless::String<64>,
     /// The expected Channel of the target AP
     ///


### PR DESCRIPTION
## Description

The `ClientConfiguration` struct can handily be parsed from a json file using `serde` and `serde_json`.

This PR adds some default values to improve the use case of defining WiFi options in a JSON file.

Without this change, those config are not valid:

Here, the auth method is missing, while it should be `WPA2Personal`:
```json
{
  "ssid": "My Wifi",
  "password": "my password"
}
```

Here, the password should be present even if not used:
```json
{
  "ssid": "Pulbic WiFi",
  "auth_method": "None"
}
```